### PR TITLE
Feature/complete alignments

### DIFF
--- a/partfinder/alignment.py
+++ b/partfinder/alignment.py
@@ -331,10 +331,18 @@ class TestAlignment(Alignment):
         self.parse(text)
 
 
-def has_all_states(Alignment):
+def check_state_probs(Alignment, subset, cfg):
+
+    # there's no problem if the user doesn't care
+    # about how many states are in a subset
+    if cfg.all_states == False:
+        return False
+
+    sub_aln = SubsetAlignment(Alignment, subset)
+
 
     dna_states = set('ACGT')
-    amino_states = set('Alanine',
+    amino_states = set(['Alanine',
                        'Arginine',
                        'Asparagine', 
                        'Aspartic acid',
@@ -353,7 +361,7 @@ def has_all_states(Alignment):
                        'Threonine',
                        'Tryptophan',
                        'Tyrosine',
-                       'Valine')
+                       'Valine'])
 
 
     dna_dict = {'A': set('A'),
@@ -372,42 +380,63 @@ def has_all_states(Alignment):
                 'H': set('ACT'),
                 'V': set('ACG'),
                 'N': set('ACGT'),
-                '?': set('ACGT')
+                '?': set('ACGT'),
+                '-': set('ACGT')
     }
 
-    amino_dict = {
-                'A': set('Alanine'),
-                'R': set('Arginine'),
-                'N': set('Asparagine'), 
-                'B': set('Asparagine'),
-                'D': set('Aspartic acid'),
-                'C': set('Cysteine'),
-                'Q': set('Glutamine'),
-                'Z': set('Glutamine'),
-                'E': set('Glutamic acid'),
-                'G': set('Glycine'),
-                'H': set('Histidine'),
-                'I': set('Isoleucine'),
-                'L': set('Leucine'),
-                'K': set('Lysine'),
-                'M': set('Methionine'),
-                'F': set('Phenylalanine'),
-                'P': set('Proline'),
-                'S': set('Serine'),
-                'T': set('Threonine'),
-                'W': set('Tryptophan'),
-                'Y': set('Tyrosine'),
-                'V': set('Valine'),
+    amino_dict = {'A': set(['Alanine']),
+                'R': set(['Arginine']),
+                'N': set(['Asparagine']), 
+                'B': set(['Asparagine']),
+                'D': set(['Aspartic acid']),
+                'C': set(['Cysteine']),
+                'Q': set(['Glutamine']),
+                'Z': set(['Glutamine']),
+                'E': set(['Glutamic acid']),
+                'G': set(['Glycine']),
+                'H': set(['Histidine']),
+                'I': set(['Isoleucine']),
+                'L': set(['Leucine']),
+                'K': set(['Lysine']),
+                'M': set(['Methionine']),
+                'F': set(['Phenylalanine']),
+                'P': set(['Proline']),
+                'S': set(['Serine']),
+                'T': set(['Threonine']),
+                'W': set(['Tryptophan']),
+                'Y': set(['Tyrosine']),
+                'V': set(['Valine']),
                 'X': amino_states,
-                '?': amino_states
+                '?': amino_states,
+                '-': amino_states
                 }
 
     # 1. Get set of all states in the alignment, obs([])
+    observed_states = numpy.unique(sub_aln.data).tostring()
 
     # 2. run through all states
-
     # for each state, extend a set of observed states, e.g. obs.add(x)
+    expanded_states = set([])
+    if cfg.datatype == 'protein':
+        all_states = amino_states
+        state_dict = amino_dict
+    elif cfg.datatype == 'DNA':
+        all_states = dna_states
+        state_dict = dna_dict
+
+    for state in observed_states:
+        try:
+            ex = state_dict[state]
+        except: #just in case
+            ex = set(state)
+
+        expanded_states = expanded_states.union(ex)
 
     #3. Compare set of observed states to set of all states. 
     # If all states are in the observed states, return TRUE
     # else return FALSE.
+    if len(all_states.difference(expanded_states)) > 0:
+        # some states are missing
+        return True
+    else:
+        return False

--- a/partfinder/alignment.py
+++ b/partfinder/alignment.py
@@ -329,3 +329,85 @@ class TestAlignment(Alignment):
     def __init__(self, text):
         Alignment.__init__(self)
         self.parse(text)
+
+
+def has_all_states(Alignment):
+
+    dna_states = set('ACGT')
+    amino_states = set('Alanine',
+                       'Arginine',
+                       'Asparagine', 
+                       'Aspartic acid',
+                       'Cysteine',
+                       'Glutamine',
+                       'Glutamic acid',
+                       'Glycine',
+                       'Histidine',
+                       'Isoleucine',
+                       'Leucine',
+                       'Lysine',
+                       'Methionine',
+                       'Phenylalanine',
+                       'Proline',
+                       'Serine',
+                       'Threonine',
+                       'Tryptophan',
+                       'Tyrosine',
+                       'Valine')
+
+
+    dna_dict = {'A': set('A'),
+                'G': set('G'),
+                'C': set('C'),
+                'T': set('T'),
+                'U': set('T'),
+                'M': set('AC'),
+                'R': set('AG'),
+                'W': set('AT'),
+                'S': set('CG'),
+                'Y': set('CT'),
+                'K': set('GT'),
+                'B': set('CGT'),
+                'D': set('AGT'),
+                'H': set('ACT'),
+                'V': set('ACG'),
+                'N': set('ACGT'),
+                '?': set('ACGT')
+    }
+
+    amino_dict = {
+                'A': set('Alanine'),
+                'R': set('Arginine'),
+                'N': set('Asparagine'), 
+                'B': set('Asparagine'),
+                'D': set('Aspartic acid'),
+                'C': set('Cysteine'),
+                'Q': set('Glutamine'),
+                'Z': set('Glutamine'),
+                'E': set('Glutamic acid'),
+                'G': set('Glycine'),
+                'H': set('Histidine'),
+                'I': set('Isoleucine'),
+                'L': set('Leucine'),
+                'K': set('Lysine'),
+                'M': set('Methionine'),
+                'F': set('Phenylalanine'),
+                'P': set('Proline'),
+                'S': set('Serine'),
+                'T': set('Threonine'),
+                'W': set('Tryptophan'),
+                'Y': set('Tyrosine'),
+                'V': set('Valine'),
+                'X': amino_states,
+                '?': amino_states
+                }
+
+    # 1. Get set of all states in the alignment, obs([])
+
+    # 2. run through all states
+
+    # for each state, extend a set of observed states, e.g. obs.add(x)
+
+    #3. Compare set of observed states to set of all states. 
+    # If all states are in the observed states, return TRUE
+    # else return FALSE.

--- a/partfinder/analysis_method.py
+++ b/partfinder/analysis_method.py
@@ -481,6 +481,16 @@ class KmeansAnalysis(Analysis):
                     split_subs[sub] = [sub]  # so we keep it whole
                     log.info("Subset %d: %d sites not splittable" %(i+1, len(sub.columns)))
 
+                elif (
+                        check_state_probs(self.alignment, split[0], the_config) == True or
+                        check_state_probs(self.alignment, split[1], the_config) == True
+                     )
+                    # we don't split it if either of the daughter subsets has problems with
+                    # the state frequencies
+                    sub.dont_split = True # never try to split this subset again
+                    split_subs[sub] = [sub]  # so we keep it whole
+                    log.info("Subset %d: %d sites not splittable" %(i+1, len(sub.columns)))
+
                 else:  # we could analyse the big subset
                     split_subs[sub] = split  # so we split it into >1
                     log.info("Subset %d: %d sites split into %d and %d"

--- a/partfinder/analysis_method.py
+++ b/partfinder/analysis_method.py
@@ -481,8 +481,15 @@ class KmeansAnalysis(Analysis):
                     # cannot split subsets, so we get back the same as we put in
                     sub.dont_split = True # never try to split this subset again
                     split_subs[sub] = [sub]  # so we keep it whole
-                    log.info("Subset %d: not splittable"
-                            %(i+1))
+                    log.info("Subset %d: %d sites not splittable" %(i+1, len(sub.columns)))
+
+                elif min([len(split[0].columns), len(split[1].columns)]) < the_config.min_subset_size:
+                    # we don't split it if either of the two daughter subset was
+                    # smaller than the minimum allowable size
+                    sub.dont_split = True # never try to split this subset again
+                    split_subs[sub] = [sub]  # so we keep it whole
+                    log.info("Subset %d: %d sites not splittable" %(i+1, len(sub.columns)))
+
                 else:  # we could analyse the big subset
                     split_subs[sub] = split  # so we split it into >1
                     log.info("Subset %d: %d sites split into %d and %d"

--- a/partfinder/analysis_method.py
+++ b/partfinder/analysis_method.py
@@ -30,6 +30,7 @@ from scipy import spatial, exp
 from scipy.misc import comb
 import numpy as np
 from config import the_config
+from alignment import SubsetAlignment
 
 class UserAnalysis(Analysis):
     def do_analysis(self):
@@ -445,6 +446,24 @@ class KmeansAnalysis(Analysis):
     def split_subsets(self, start_subsets, tree_path):
         split_subs = {}
         for i, sub in enumerate(start_subsets):
+
+
+
+
+
+            
+            sub_alignment = SubsetAlignment(self.alignment, sub)
+            # here we can test if the alignment has all states:
+            print "alignment has all states?", alignment.has_all_states(sub_alignment)
+
+
+
+
+
+
+
+
+
             if len(sub.columns) == 1 or len(sub.columns) < the_config.min_subset_size:
                 split_subs[sub] = [sub]
             else:

--- a/partfinder/config.py
+++ b/partfinder/config.py
@@ -45,7 +45,7 @@ class Configuration(object):
 
     def init(self, datatype="DNA", phylogeny_program='phyml',
                  save_phylofiles=False, cmdline_extras="", cluster_weights=None,
-                 cluster_percent=10.0, cluster_max=1000, kmeans='entropy', quick=False, min_subset_size = 100):
+                 cluster_percent=10.0, cluster_max=1000, kmeans='entropy', quick=False, min_subset_size = 100, all_states = False):
 
 
         log.info("------------- Configuring Parameters -------------")
@@ -65,6 +65,7 @@ class Configuration(object):
         self.kmeans = kmeans
         self.quick = quick
         self.min_subset_size = min_subset_size
+        self.all_states = all_states
 
 
         # Record this

--- a/partfinder/main.py
+++ b/partfinder/main.py
@@ -223,6 +223,12 @@ def parse_args(datatype, cmdargs=None):
              " Possible regions are 'all' or any of {%s}."
              % ",".join(get_debug_regions())
     )
+    op.add_option(
+        "--all-states",
+        action="store_true", dest="all_states", default=False,
+        help="In the k-means algorithm, only produce subsets which have "
+             "all states represented (e.g. ACTG for DNA datasets)."
+    )
 
     op.add_option(
         '--profile',
@@ -359,7 +365,8 @@ def main(name, datatype, passed_args=None):
                                    options.cluster_max,
                                    options.kmeans, 
                                    options.quick,
-                                   options.min_subset_size)
+                                   options.min_subset_size,
+                                   options.all_states)
         cfg = config.the_config
 
         # Set up the progress callback

--- a/partfinder/reporter.py
+++ b/partfinder/reporter.py
@@ -225,6 +225,10 @@ class TextReporter(object):
                                                    self.cfg.min_subset_size))
             output.write(scheme_header_template % ("kmeans based on",
                                                    self.cfg.kmeans))
+            if self.cfg.all_states == True:
+                output.write(scheme_header_template % ("--all_states setting used",
+                                                       self.cfg.all_states))
+
 
         output.write('\n\nBest partitioning scheme\n\n')
         self.output_scheme(result.best_scheme, result.best_result, output)

--- a/partfinder/subset.py
+++ b/partfinder/subset.py
@@ -326,6 +326,7 @@ class Subset(object):
     def make_alignment(self, cfg, alignment):
         # Make an Alignment from the source, using this subset
         sub_alignment = SubsetAlignment(alignment, self)
+
         sub_path = os.path.join(cfg.phylofiles_path, self.subset_id + '.phy')
         # Add it into the sub, so we keep it around
         self.alignment_path = sub_path


### PR DESCRIPTION
this merge adds one major feature:

--all-states

this is a command line flag which lets users specify that they only want to retain subsets that contain all states when using the kmeans algorithm. (E.g. ACTG when using DNA sequences).

Currently, this is interpreted such that a gap, N, or ? is treated as giving that subset all states. And for amino acids, it’s gap, X, or ?. This could be changed, but it depends a little on how folks use the feature and what they want.