### PR TITLE
Feature/merge little subsets

### DIFF
--- a/partfinder/analysis_method.py
+++ b/partfinder/analysis_method.py
@@ -291,6 +291,55 @@ class RelaxedClusteringAnalysis(Analysis):
     4. Quit if no improvements.
     '''
 
+    def clean_scheme(self, start_scheme):
+        # Here we look for and fix up subsets that are too small or don't have all states
+        keep_going = 1
+        merges = 0
+        if keep_going == 1:
+            with logtools.indented(log, "*** Checking subsets from scheme '%s' meet --min-subset-size and --all_states settings ***" %start_scheme.name):
+                while keep_going > 0:
+
+                    subsets = [s for s in start_scheme.subsets]
+                    
+                    # sort the subsets, to keep results consistent over re-runs
+                    subsets.sort(key = lambda x: 1.0/float(len(x.columns)))
+                    
+                    # run through all subsets
+                    for i, sub in enumerate(subsets):
+                        found = 0
+                        state_problems = self.alignment.check_state_probs(sub, the_config)
+
+                        if  (
+                                len(sub.columns) < the_config.min_subset_size or 
+                                state_problems == True
+                            ):
+
+                            # merge that subset with nearest neighbour
+                            new_pair = neighbour.get_closest_subset(sub, subsets, the_config)
+
+                            log.info("Subset '%s' will be merged with subset '%s'" %(new_pair[0].name, new_pair[1].name))
+                            new_pair_merged = subset_ops.merge_subsets(new_pair)
+                            start_scheme = neighbour.make_clustered_scheme(
+                                    start_scheme, "start_scheme", new_pair, new_pair_merged, the_config)
+                            the_config.progress.begin(1, 1)
+                            self.analyse_scheme(start_scheme)
+                            subsets = [s for s in start_scheme.subsets]
+                            merges = merges + 1
+                            found = 1
+                            break
+
+
+                    # if we got to here, there were no subsets to merge
+                    if found == 0:
+                        keep_going = 0
+
+                    if len(subsets) == 1:
+                        log.error("The settings you have used for --all-states and/or --min-subset-size mean that all of your subsets have been merged into one prior to any analysis. Thus, no analysis is necessary. Please check and try again")
+                        raise AnalysisError
+
+                log.info("%d subsets merged because of --min-subset-size and/or --all-states settings" % merges)
+        return(start_scheme)
+
     @logtools.log_info(log, "Performing relaxed clustering analysis")
     def do_analysis(self):
 
@@ -318,56 +367,9 @@ class RelaxedClusteringAnalysis(Analysis):
                 the_config.reporter.write_scheme_summary(
                     self.results.best_scheme, self.results.best_result)
 
-        # Here we look for and fix up subsets that are too small or don't have all states
+
         if the_config.min_subset_size or the_config.all_states:
-            keep_going = 1
-        else:
-            keep_going = 0
-        merges = 0
-        if keep_going == 1:
-            with logtools.indented(log, "*** Checking starting scheme subsets meet --min-subset-size and --all_states settings ***"):
-                while keep_going > 0:
-
-                    subsets = [s for s in start_scheme.subsets]
-                    
-                    # sort the subsets, to keep results consistent over re-runs
-                    subsets.sort(key = lambda x: 1.0/float(len(x.columns)))
-                    
-                    # run through all subsets
-                    for i, sub in enumerate(subsets):
-                        found = 0
-                        state_problems = self.alignment.check_state_probs(sub, the_config)
-
-                        if  (
-                                len(sub.columns) < the_config.min_subset_size or 
-                                state_problems == True
-                            ):
-
-                            # merge that subset with nearest neighbour
-                            new_pair = neighbour.get_closest_subset(sub, subsets, the_config)
-
-                            log.info("Subset '%s' will be merged with subset '%s'" %(new_pair[0].name, new_pair[1].name))
-                            new_pair_merged = subset_ops.merge_subsets(new_pair)
-                            start_scheme = neighbour.make_clustered_scheme(
-                                    start_scheme, "start_scheme", new_pair, new_pair_merged, the_config)
-                            the_config.progress.begin(scheme_count, 1)
-                            self.analyse_scheme(start_scheme)
-                            subsets = [s for s in start_scheme.subsets]
-                            merges = merges + 1
-                            found = 1
-                            break
-
-
-                    # if we got to here, there were no subsets to merge
-                    if found == 0:
-                        keep_going = 0
-
-                    if len(subsets) == 1:
-                        log.error("The settings you have used for --all-states and/or --min-subset-size mean that all of your subsets have been merged into one prior to any analysis. Thus, no analysis is necessary. Please check and try again")
-                        raise AnalysisError
-
-                log.info("%d subsets merged because of --min-subset-size and/or --all-states settings" % merges)
-                log.info("%d subsets merged because of --min-subset-size and/or --all-states settings" % merges)
+            start_scheme = self.clean_scheme(start_scheme)
 
         subsets = [s for s in start_scheme.subsets]
         partnum = len(subsets)

--- a/partfinder/analysis_method.py
+++ b/partfinder/analysis_method.py
@@ -318,8 +318,63 @@ class RelaxedClusteringAnalysis(Analysis):
                 the_config.reporter.write_scheme_summary(
                     self.results.best_scheme, self.results.best_result)
 
-        subsets = [s for s in start_scheme.subsets]
+        # Here we look for and fix up subsets that are too small or don't have all states
+        if the_config.min_subset_size or the_config.all_states:
+            keep_going = 1
+        else:
+            keep_going = 0
+        merges = 0
+        with logtools.indented(log, "*** Checking starting scheme subsets meet --min-subset-size and --all_states settings ***"):
+            while keep_going > 0:
 
+                subsets = [s for s in start_scheme.subsets]
+                
+                # sort the subsets, to keep results consistent over re-runs
+                subsets.sort(key = lambda x: 1.0/float(len(x.columns)))
+                
+                # run through all subsets
+                for i, sub in enumerate(subsets):
+                    found = 0
+                    state_problems = self.alignment.check_state_probs(sub, the_config)
+
+                    if  (
+                            len(sub.columns) < the_config.min_subset_size or 
+                            state_problems == True
+                        ):
+
+                        # merge that subset with nearest neighbour
+                        new_pair = neighbour.get_closest_subset(sub, subsets, the_config)
+
+                        log.info("Subset '%s' will be merged with subset '%s'" %(new_pair[0].name, new_pair[1].name))
+                        new_pair_merged = subset_ops.merge_subsets(new_pair)
+                        start_scheme = neighbour.make_clustered_scheme(
+                                start_scheme, "start_scheme", new_pair, new_pair_merged, the_config)
+                        the_config.progress.begin(scheme_count, 1)
+                        self.analyse_scheme(start_scheme)
+                        subsets = [s for s in start_scheme.subsets]
+                        merges = merges + 1
+                        found = 1
+                        break
+
+
+                # if we got to here, there were no subsets to merge
+                if found == 0:
+                    keep_going = 0
+
+                if len(subsets) == 1:
+                    log.error("The settings you have used for --all-states and/or --min-subset-size mean that all of your subsets have been merged into one prior to any analysis. Thus, no analysis is necessary. Please check and try again")
+                    raise AnalysisError
+
+            log.info("%d subsets merged because of --min-subset-size and/or --all-states settings" % merges)
+
+        subsets = [s for s in start_scheme.subsets]
+        partnum = len(subsets)
+        # we do this analysis to guard against the rare (but possible) situation that 
+        # the best scheme is actually one with invalid subsets, that were merged in the
+        # previous steps. It's not ideal. But it means that the rest of the analysis
+        # will definitely start from the basis that we compare thing to the starting
+        # schem AFTER merging invalid subsets
+        self.results.best_score = self.analyse_scheme(start_scheme).score
         step = 1
         while True:
             with logtools.indented(log, "*** Relaxed clustering algorithm step %d of up to %d ***"

--- a/partfinder/analysis_method.py
+++ b/partfinder/analysis_method.py
@@ -320,7 +320,7 @@ class RelaxedClusteringAnalysis(Analysis):
                             log.info("Subset '%s' will be merged with subset '%s'" %(new_pair[0].name, new_pair[1].name))
                             new_pair_merged = subset_ops.merge_subsets(new_pair)
                             start_scheme = neighbour.make_clustered_scheme(
-                                    start_scheme, "start_scheme", new_pair, new_pair_merged, the_config)
+                                    start_scheme, "cleaned_scheme", new_pair, new_pair_merged, the_config)
                             the_config.progress.begin(1, 1)
                             self.analyse_scheme(start_scheme)
                             subsets = [s for s in start_scheme.subsets]

--- a/partfinder/analysis_method.py
+++ b/partfinder/analysis_method.py
@@ -367,6 +367,7 @@ class RelaxedClusteringAnalysis(Analysis):
                         raise AnalysisError
 
                 log.info("%d subsets merged because of --min-subset-size and/or --all-states settings" % merges)
+                log.info("%d subsets merged because of --min-subset-size and/or --all-states settings" % merges)
 
         subsets = [s for s in start_scheme.subsets]
         partnum = len(subsets)
@@ -375,8 +376,9 @@ class RelaxedClusteringAnalysis(Analysis):
         # previous steps. It's not ideal. But it means that the rest of the analysis
         # will definitely start from the basis that we compare thing to the starting
         # schem AFTER merging invalid subsets
-        self.results.best_result = self.analyse_scheme(start_scheme) 
-        self.results.best_score = start_scheme.score
+        best_result = self.analyse_scheme(start_scheme)
+        self.results.best_result = best_result 
+        self.results.best_score = best_result.score
         self.results.best_scheme = start_scheme
         step = 1
         while True:

--- a/partfinder/analysis_method.py
+++ b/partfinder/analysis_method.py
@@ -496,6 +496,8 @@ class RelaxedClusteringAnalysis(Analysis):
 
 class KmeansAnalysis(Analysis):
 
+    # set the default subset size to 100 for kmeans analyses
+    the_config.min_subset_size = 100
 
     def split_subsets(self, start_subsets, tree_path):
         split_subs = {}

--- a/partfinder/analysis_method.py
+++ b/partfinder/analysis_method.py
@@ -375,7 +375,9 @@ class RelaxedClusteringAnalysis(Analysis):
         # previous steps. It's not ideal. But it means that the rest of the analysis
         # will definitely start from the basis that we compare thing to the starting
         # schem AFTER merging invalid subsets
-        self.results.best_score = self.analyse_scheme(start_scheme).score
+        self.results.best_result = self.analyse_scheme(start_scheme) 
+        self.results.best_score = start_scheme.score
+        self.results.best_scheme = start_scheme
         step = 1
         while True:
             with logtools.indented(log, "*** Relaxed clustering algorithm step %d of up to %d ***"

--- a/partfinder/analysis_method.py
+++ b/partfinder/analysis_method.py
@@ -324,48 +324,49 @@ class RelaxedClusteringAnalysis(Analysis):
         else:
             keep_going = 0
         merges = 0
-        with logtools.indented(log, "*** Checking starting scheme subsets meet --min-subset-size and --all_states settings ***"):
-            while keep_going > 0:
+        if keep_going == 1:
+            with logtools.indented(log, "*** Checking starting scheme subsets meet --min-subset-size and --all_states settings ***"):
+                while keep_going > 0:
 
-                subsets = [s for s in start_scheme.subsets]
-                
-                # sort the subsets, to keep results consistent over re-runs
-                subsets.sort(key = lambda x: 1.0/float(len(x.columns)))
-                
-                # run through all subsets
-                for i, sub in enumerate(subsets):
-                    found = 0
-                    state_problems = self.alignment.check_state_probs(sub, the_config)
+                    subsets = [s for s in start_scheme.subsets]
+                    
+                    # sort the subsets, to keep results consistent over re-runs
+                    subsets.sort(key = lambda x: 1.0/float(len(x.columns)))
+                    
+                    # run through all subsets
+                    for i, sub in enumerate(subsets):
+                        found = 0
+                        state_problems = self.alignment.check_state_probs(sub, the_config)
 
-                    if  (
-                            len(sub.columns) < the_config.min_subset_size or 
-                            state_problems == True
-                        ):
+                        if  (
+                                len(sub.columns) < the_config.min_subset_size or 
+                                state_problems == True
+                            ):
 
-                        # merge that subset with nearest neighbour
-                        new_pair = neighbour.get_closest_subset(sub, subsets, the_config)
+                            # merge that subset with nearest neighbour
+                            new_pair = neighbour.get_closest_subset(sub, subsets, the_config)
 
-                        log.info("Subset '%s' will be merged with subset '%s'" %(new_pair[0].name, new_pair[1].name))
-                        new_pair_merged = subset_ops.merge_subsets(new_pair)
-                        start_scheme = neighbour.make_clustered_scheme(
-                                start_scheme, "start_scheme", new_pair, new_pair_merged, the_config)
-                        the_config.progress.begin(scheme_count, 1)
-                        self.analyse_scheme(start_scheme)
-                        subsets = [s for s in start_scheme.subsets]
-                        merges = merges + 1
-                        found = 1
-                        break
+                            log.info("Subset '%s' will be merged with subset '%s'" %(new_pair[0].name, new_pair[1].name))
+                            new_pair_merged = subset_ops.merge_subsets(new_pair)
+                            start_scheme = neighbour.make_clustered_scheme(
+                                    start_scheme, "start_scheme", new_pair, new_pair_merged, the_config)
+                            the_config.progress.begin(scheme_count, 1)
+                            self.analyse_scheme(start_scheme)
+                            subsets = [s for s in start_scheme.subsets]
+                            merges = merges + 1
+                            found = 1
+                            break
 
 
-                # if we got to here, there were no subsets to merge
-                if found == 0:
-                    keep_going = 0
+                    # if we got to here, there were no subsets to merge
+                    if found == 0:
+                        keep_going = 0
 
-                if len(subsets) == 1:
-                    log.error("The settings you have used for --all-states and/or --min-subset-size mean that all of your subsets have been merged into one prior to any analysis. Thus, no analysis is necessary. Please check and try again")
-                    raise AnalysisError
+                    if len(subsets) == 1:
+                        log.error("The settings you have used for --all-states and/or --min-subset-size mean that all of your subsets have been merged into one prior to any analysis. Thus, no analysis is necessary. Please check and try again")
+                        raise AnalysisError
 
-            log.info("%d subsets merged because of --min-subset-size and/or --all-states settings" % merges)
+                log.info("%d subsets merged because of --min-subset-size and/or --all-states settings" % merges)
 
         subsets = [s for s in start_scheme.subsets]
         partnum = len(subsets)

--- a/partfinder/analysis_method.py
+++ b/partfinder/analysis_method.py
@@ -368,20 +368,9 @@ class RelaxedClusteringAnalysis(Analysis):
                     self.results.best_scheme, self.results.best_result)
 
 
-        if the_config.min_subset_size or the_config.all_states:
-            start_scheme = self.clean_scheme(start_scheme)
 
         subsets = [s for s in start_scheme.subsets]
         partnum = len(subsets)
-        # we do this analysis to guard against the rare (but possible) situation that 
-        # the best scheme is actually one with invalid subsets, that were merged in the
-        # previous steps. It's not ideal. But it means that the rest of the analysis
-        # will definitely start from the basis that we compare thing to the starting
-        # schem AFTER merging invalid subsets
-        best_result = self.analyse_scheme(start_scheme)
-        self.results.best_result = best_result 
-        self.results.best_score = best_result.score
-        self.results.best_scheme = start_scheme
         step = 1
         while True:
             with logtools.indented(log, "*** Relaxed clustering algorithm step %d of up to %d ***"
@@ -496,6 +485,17 @@ class RelaxedClusteringAnalysis(Analysis):
         log.info("Best scoring scheme is scheme %s, with %s score of %.3f"
                  % (self.results.best_scheme.name, model_selection,
                     self.results.best_score))
+
+        if the_config.min_subset_size or the_config.all_states:
+            best_scheme = self.clean_scheme(best_scheme)
+            best_result = self.analyse_scheme(best_scheme)
+            self.results.best_result = best_result 
+            self.results.best_score = best_result.score
+            self.results.best_scheme = best_scheme
+            log.info("Best scoring scheme after cleaning is scheme %s, with %s score of %.3f"
+                     % (self.results.best_scheme.name, model_selection,
+                        self.results.best_score))
+
 
         the_config.reporter.write_best_scheme(self.results)
 

--- a/partfinder/main.py
+++ b/partfinder/main.py
@@ -183,7 +183,7 @@ def parse_args(datatype, cmdargs=None):
     op.add_option(
         "--kmeans",
         type="str", dest="kmeans", default='entropy', metavar="type",
-        help="This defines which sitewise values to use: entropy or tiger"
+        help="This defines which sitewise values to use: entropy or tiger "
              "\n--kmeans entropy: use entropies for sitewise values"
              "\n--kmeans tiger: use TIGER rates for sitewise values"
     )
@@ -192,7 +192,7 @@ def parse_args(datatype, cmdargs=None):
         type="float", dest="cluster_percent", default=10.0, metavar="N",
         help="This defines the proportion of possible schemes that the relaxed clustering"
              " algorithm will consider before it stops looking. The default is 10%."
-             "e.g. --rcluster-percent 10.0"
+             "\ne.g. --rcluster-percent 10.0"
     )
     op.add_option(
         "--rcluster-max",
@@ -200,16 +200,18 @@ def parse_args(datatype, cmdargs=None):
         help="This defines the number of possible schemes that the relaxed clustering"
              " algorithm will consider before it stops looking. The default is to look at "
              "just the top 1000 schemes."
-             "e.g. --rcluster-max 1000"
+             "\ne.g. --rcluster-max 1000"
     )
     op.add_option(
         "--min-subset-size",
-        type="int", dest="min_subset_size", default=100, metavar="N",
-        help="This defines the minimum subset size that you will accept for"
-             " the kmeans algorithm. Subsets smaller than this will still be "
-             "created during the algorithm, but they will be merged with other"
-             " subsets at the end of the algorithm."
-             "e.g. --min-subset-size 100"
+        type="int", dest="min_subset_size", default=False, metavar="N",
+        help="This defines the minimum subset size that the kmeans and rcluster"
+             " algorithm will accept. Subsets smaller than this "
+             " will be merged at with other subsets at the end of the algorithm"
+             " (for kmeans) or at the start of the algorithm (for rcluster)."
+             " See manual for details. The default value for kmeans is 100."
+             " The default value for rcluster is to ignore this option."
+             "\ne.g. --min-subset-size 100"
     )
     op.add_option(
         '--debug-output',
@@ -226,8 +228,11 @@ def parse_args(datatype, cmdargs=None):
     op.add_option(
         "--all-states",
         action="store_true", dest="all_states", default=False,
-        help="In the k-means algorithm, only produce subsets which have "
-             "all states represented (e.g. ACTG for DNA datasets)."
+        help="In the kmeans and rcluster algorithms, this stipulates that PartitionFinder "
+             "should not produce subsets that do not have all possible states present. E.g."
+             " for DNA sequence data, all subsets in the final scheme must have A, C, T, "
+             " and G nucleotides present. This can occasionally be useful for downstream "
+             " analyses, particularly concerning amino acid datasets."
     )
 
     op.add_option(

--- a/partfinder/neighbour.py
+++ b/partfinder/neighbour.py
@@ -128,6 +128,30 @@ def get_N_closest_subsets(subsets, cfg, N, distance_matrix = np.matrix([])):
     return ranked_subset_groupings
 
 
+
+def get_closest_subset(sub, subsets, cfg, distance_matrix = np.matrix([])):
+    """Find the most similar subsets to the focal subset 'sub'
+    """
+    if not distance_matrix.any():
+        distance_matrix = get_distance_matrix(subsets, cfg.cluster_weights)
+        distance_matrix = scipy.spatial.distance.squareform(distance_matrix)
+        
+    try:
+        col = subsets.index(sub)
+    except:
+        log.error("Couldn't find the subset you were looking for")
+        raise PartitionFinderError
+
+    sub_col = distance_matrix[col,]
+
+    sub_closest = np.min(sub_col[np.nonzero(sub_col)])
+
+    closest_index = int(np.where(sub_col == sub_closest)[0])
+
+    closest_subset = subsets[closest_index]
+
+    return([sub, closest_subset])
+
 def make_clustered_scheme(start_scheme, scheme_name, subsets_to_cluster, merged_sub, cfg):
 
     # 1. Then we define a new scheme with those merged subsets


### PR DESCRIPTION
this feature fixes up subsets at the end of an rcluster run. This only happens if the user specifies the —all-states or —min-subset-size flags. At the end of the rcluster run, any subsets that fail these tests (i.e. don’t have all states and/or are smaller than the specified minimum size) are merged with their nearest neighbour subsets. Nearest neighbour is defined by the manhattan distance, using the user-specified weights. 