### PR TITLE
Catch edge case of single partition in greedy algorithm

### DIFF
--- a/partfinder/algorithm.py
+++ b/partfinder/algorithm.py
@@ -73,7 +73,7 @@ def lumpings(scheme):
         sub = list(sub)
         sub.sort()
         #now replace all the instance of one number in lump with the other in sub
-        while lump.count(sub[1]) > 0:
+        while len(sub) > 1 and lump.count(sub[1]) > 0:
             lump[lump.index(sub[1])] = sub[0]
         lumpings.append(lump)
 


### PR DESCRIPTION
The program crashed during greedy 'lumping' loop if only a single partition was present.
Add an extra logical operation in 'while' test to catch this state and pass through safely.