### PR TITLE
Prevent partitionfinder crash when passing in a single partition.

### DIFF
--- a/partfinder/algorithm.py
+++ b/partfinder/algorithm.py
@@ -74,7 +74,7 @@ def lumpings(scheme):
         sub.sort()
         # Now replace all the instance of one number in lump with the other in
         # sub
-        while lump.count(sub[1]) > 0:
+        while len(sub) > 1 and lump.count(sub[1]) > 0:
             lump[lump.index(sub[1])] = sub[0]
         lumpings.append(lump)
 

--- a/partfinder/neighbour.py
+++ b/partfinder/neighbour.py
@@ -58,7 +58,7 @@ def get_manhattan_matrix(rates, freqs, model, alpha, weights):
 
     if weights["rate"] > 0:
         r_dists = scipy.spatial.distance.pdist(np.array(rates), 'cityblock')
-        if np.amax(r_dists)>0:        
+        if r_dists and np.amax(r_dists)>0:
             norm = float(weights["rate"])/float(np.amax(r_dists))
             r_dists = np.multiply(r_dists, norm)
         distance_arrays.append(r_dists)


### PR DESCRIPTION
This allows partitionfinder to be used as a straight-up wrapper for model testing on a given alignment.