### PR TITLE
commas removed between sites in MrBayes block

### DIFF
--- a/partfinder/reporter.py
+++ b/partfinder/reporter.py
@@ -229,7 +229,7 @@ class TextReporter(object):
         for sub in sorted_subsets:
             if self.cfg.search in _odd_searches:
                 sites = [x + 1 for x in sub.columns]
-                partition_sites = str(sites).strip('[]')
+                partition_sites = str(sites).strip('[]').replace(',','')
             else:
                 partition_sites = sub.site_description_no_commas
 


### PR DESCRIPTION
MrBayes does not accept commas separating sites in the lit of charsets. This worked correctly for site descriptions with multiple ranges but not for odd sites.