### PR TITLE
Fix: call scipy.misc.comb with exact=True

### DIFF
--- a/partfinder/analysis_method.py
+++ b/partfinder/analysis_method.py
@@ -172,7 +172,7 @@ class GreedyAnalysis(Analysis):
                 name_prefix = "step_%d" % (step)
 
                 # get distances between subsets
-                max_schemes = comb(len(start_scheme.subsets), 2)
+                max_schemes = comb(len(start_scheme.subsets), 2, exact=True)
 
                 # this is a fake distance matrix, so that the greedy algorithm
                 # can use all the tricks of the relaxed clustering algorithm


### PR DESCRIPTION
I got an error running PartitionFinder with SciPy 0.19.0:
```
[...]
INFO     | 2017-05-22 16:31:39,021 |    ***Greedy algorithm step 1***
Traceback (most recent call last):
  File "/home/sereina/src/partitionfinder/PartitionFinder.py", line 23, in <module>
    sys.exit(main.main("PartitionFinder", "DNA"))
  File "/home/sereina/src/partitionfinder/partfinder/main.py", line 399, in main
    run_analysis(cfg, options)
  File "/home/sereina/src/partitionfinder/partfinder/main.py", line 333, in run_analysis
    results = anal.analyse()
  File "/home/sereina/src/partitionfinder/partfinder/analysis.py", line 93, in analyse
    self.do_analysis()
  File "/home/sereina/src/partitionfinder/partfinder/logtools.py", line 159, in indented_fn
    fn(*args, **kwargs)
  File "/home/sereina/src/partitionfinder/partfinder/analysis_method.py", line 193, in do_analysis
    subsets, the_config, cutoff, d_matrix)
  File "/home/sereina/src/partitionfinder/partfinder/neighbour.py", line 127, in get_N_closest_subsets
    ranked_subset_groupings = get_ranked_list(distance_matrix, subsets, N)
  File "/home/sereina/src/partitionfinder/partfinder/neighbour.py", line 38, in get_ranked_list
    closest = distance_matrix.argsort()[:N]
TypeError: slice indices must be integers or None or have an __index__ method
```
which seems to be due to the fact that the return value of `scipy.misc.comb` is passed on to be used as an index later on in `neighbour.py::get_ranked_list()`. The error log is attached to this PR:
[parfi.e60266.txt](https://github.com/brettc/partitionfinder/files/1021208/parfi.e60266.txt)

A quick fix is to call `scipy.misc.comb` with parameter `exact=True`, so that the return value will be an integer (works for SciPy 0.19.0 as well as SciPy 0.13.0).